### PR TITLE
souffle-haskell: use overlay, fix sofialude/relude (fixes #1)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,22 +1,26 @@
 {
   "nodes": {
-    "flake-compat": {
-      "flake": false,
+    "ds": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_3"
+      },
       "locked": {
-        "lastModified": 1627913399,
-        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "lastModified": 1644227066,
+        "narHash": "sha256-FHcFZtpZEWnUh62xlyY3jfXAXHzJNEDLDzLsJxn+ve0=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "7033f64dd9ef8d9d8644c5030c73913351d2b660",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
+        "owner": "numtide",
+        "ref": "master",
+        "repo": "devshell",
         "type": "github"
       }
     },
-    "flake-compat_2": {
+    "flake-compat": {
       "flake": false,
       "locked": {
         "lastModified": 1627913399,
@@ -64,26 +68,11 @@
     },
     "flake-utils_3": {
       "locked": {
-        "lastModified": 1629481132,
-        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_4": {
-      "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
         "type": "github"
       },
       "original": {
@@ -108,58 +97,19 @@
         "type": "github"
       }
     },
-    "gitignore": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1611672876,
-        "narHash": "sha256-qHu3uZ/o9jBHiA3MEKHJ06k7w4heOhA+4HCSIvflRxo=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "211907489e9f198594c0eb0ca9256a1949c9d412",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "hls": {
-      "inputs": {
-        "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_3",
-        "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs_3",
-        "pre-commit-hooks": "pre-commit-hooks"
-      },
-      "locked": {
-        "lastModified": 1640382017,
-        "narHash": "sha256-o/3unZLhE/KPoXgdsJYBPJWAeMNiVyzWwPUR+YBTOUg=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "7c9b9327d83261a6d40e54a4a2078667f0ddc7bd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "master",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642970779,
-        "narHash": "sha256-wccCiIecPkPE6wpidSRe9XEdJ6uCrNLmRtuhNwt1Kuk=",
+        "lastModified": 1645977382,
+        "narHash": "sha256-H9rNufoDgPU4mbUNwjminPGmsmVstteh93uwEl0SLlA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a3d847c3bd3a3b75b3057d7b3730d3308dd8fd59",
+        "rev": "964ffb4697d1741ad7ea042a4b2c5a61cf129456",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
+        "ref": "master",
         "repo": "nixpkgs",
-        "rev": "a3d847c3bd3a3b75b3057d7b3730d3308dd8fd59",
         "type": "github"
       }
     },
@@ -181,11 +131,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1639357775,
-        "narHash": "sha256-mJJFCPqZi1ZO3CvgEfN2nFAYv4uAJSRnTKzLFi61+WA=",
+        "lastModified": 1643381941,
+        "narHash": "sha256-pHTwvnN4tTsEKkWlXQ8JMY423epos8wUOhthpwJjtpc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c473cc8714710179df205b153f4e9fa007107ff9",
+        "rev": "5efc8ca954272c4376ac929f4c5ffefcc20551d5",
         "type": "github"
       },
       "original": {
@@ -195,52 +145,19 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1640328990,
-        "narHash": "sha256-KQbvJx4qO9bo04tfTZuISyY4vRC5k3ZB3lyLS21XWIw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ab93217a2b74a1c36bc892c14f44ee5959c33f12",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
     "np": {
       "locked": {
-        "lastModified": 1640390856,
-        "narHash": "sha256-bBLSbuAp+f1/C0SSwvi7Gb5hAotGt/Lr4e233zb8DmU=",
+        "lastModified": 1645977382,
+        "narHash": "sha256-H9rNufoDgPU4mbUNwjminPGmsmVstteh93uwEl0SLlA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0587013dd2719891573732e5c0fd718e92b25501",
+        "rev": "964ffb4697d1741ad7ea042a4b2c5a61cf129456",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "haskell-updates",
+        "ref": "master",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "pre-commit-hooks": {
-      "inputs": {
-        "flake-utils": "flake-utils_4",
-        "nixpkgs": "nixpkgs_4"
-      },
-      "locked": {
-        "lastModified": 1624971177,
-        "narHash": "sha256-Amf/nBj1E77RmbSSmV+hg6YOpR+rddCbbVgo5C7BS0I=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "397f0713d007250a2c7a745e555fa16c5dc8cadb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
         "type": "github"
       }
     },
@@ -274,20 +191,21 @@
     },
     "souffle-haskell": {
       "inputs": {
+        "ds": "ds",
         "fu": "fu",
-        "hls": "hls",
         "np": "np"
       },
       "locked": {
-        "lastModified": 1644872593,
-        "narHash": "sha256-thTwybVSDczJDQ3gJ5UZAJb+2AAZmkHHfUNbfmhQLTo=",
-        "owner": "luc-tielen",
+        "lastModified": 1645977472,
+        "narHash": "sha256-V1+L2977EzPTgAj71q8eh+HHWsespkqf+Tb0seGBM2o=",
+        "owner": "smunix",
         "repo": "souffle-haskell",
-        "rev": "11671673c13d0fa6067bf841278a6dfd234885c0",
+        "rev": "86d9ab3b3f7060d847e21ce243c91d278937ff4b",
         "type": "github"
       },
       "original": {
-        "owner": "luc-tielen",
+        "owner": "smunix",
+        "ref": "fix.57",
         "repo": "souffle-haskell",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,58 +1,61 @@
 {
   description = "sofyr";
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/a3d847c3bd3a3b75b3057d7b3730d3308dd8fd59";
+    nixpkgs.url = "github:nixos/nixpkgs?ref=master";
     flake-utils.url = "github:numtide/flake-utils";
-    souffle-haskell.url = "github:luc-tielen/souffle-haskell";
+    souffle-haskell.url = "github:smunix/souffle-haskell?ref=fix.57";
     sofialude.url = "github:sofia-m-a/sofialude";
   };
-  outputs = inputs@{ self, nixpkgs, flake-utils, souffle-haskell, sofialude, ... }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ] (system:
+  outputs =
+    inputs@{ self, nixpkgs, flake-utils, souffle-haskell, sofialude, ... }:
+    flake-utils.lib.eachSystem [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ] (system:
       let
-        overlays = [ ]
-          ++ souffle-haskell.overlays.${system} # bring in souffle/souffle-haskell
-          ++ [
-          (self: super: {
-            haskellPackages = super.haskellPackages.override {
-              overrides = hself: hsuper: {
-                souffle-haskell = super.souffle-haskell;
+        overlays = [
+          (f: _:
+            with f.haskellPackages; {
+              sofialude = callCabal2nix "sofialude" sofialude {
+                relude = relude_1_0_0_1;
               };
-            };
-          })
-        ]; # this overlay is necessary because github:luc-tielen/souffle-haskell doesn't stick these in haskellPackages
-
-        pkgs =
-          import nixpkgs { inherit system overlays; config.allowBroken = true; };
+            })
+          souffle-haskell.overlay.${system}
+        ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+          config.allowBroken = true;
+        };
 
         # https://github.com/NixOS/nixpkgs/issues/140774#issuecomment-976899227
-        m1MacHsBuildTools =
-          pkgs.haskellPackages.override {
-            overrides = self: super:
-              let
-                workaround140774 = hpkg: with pkgs.haskell.lib;
-                  overrideCabal hpkg (drv: {
-                    enableSeparateBinOutput = false;
-                  });
-              in
-              {
-                ghcid = workaround140774 super.ghcid;
-                ormolu = workaround140774 super.ormolu;
-              };
-          };
+        m1MacHsBuildTools = pkgs.haskellPackages.override {
+          overrides = self: super:
+            let
+              workaround140774 = hpkg:
+                with pkgs.haskell.lib;
+                overrideCabal hpkg (drv: { enableSeparateBinOutput = false; });
+            in {
+              ghcid = workaround140774 super.ghcid;
+              ormolu = workaround140774 super.ormolu;
+            };
+        };
         project = returnShellEnv:
           pkgs.haskellPackages.developPackage {
             inherit returnShellEnv;
             name = "sofyr";
             root = ./.;
             withHoogle = false;
-            overrides = self: super: with pkgs.haskell.lib; {
-              inherit sofialude;
-            };
+            overrides = self: super:
+              with pkgs.haskell.lib; {
+                inherit (pkgs) sofialude;
+              };
             modifier = drv:
               pkgs.haskell.lib.addBuildTools drv
-                (with (if system == "aarch64-darwin"
-                then m1MacHsBuildTools
-                else pkgs.haskellPackages); [
+              (with (if system == "aarch64-darwin" then
+                m1MacHsBuildTools
+              else
+                pkgs.haskellPackages); [
                   # Specify your build/dev dependencies here.
                   cabal-fmt
                   cabal-install
@@ -60,12 +63,10 @@
                   haskell-language-server
                   ormolu
                   pkgs.souffle
-
                   pkgs.nixpkgs-fmt
                 ]);
           };
-      in
-      {
+      in {
         # Used by `nix build` & `nix run` (prod exe)
         defaultPackage = project false;
 


### PR DESCRIPTION
This fixes #1, and at the same also fixes the build to compile sofialude with the right version of relude.
Tested with:
```sh
❯ nix build 'github:smunix/sofyr?ref=fix.1'
```
